### PR TITLE
fix: mutex protect krusty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ fmt:
 
 .PHONY: test
 test:
-	go test -coverprofile coverage.out -v ./...
+	go test -race -coverprofile coverage.out -v ./...
 
 .PHONY: e2e-test
 e2e-test: build

--- a/internal/build/kustomize.go
+++ b/internal/build/kustomize.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kustomize/api/konfig"
@@ -16,6 +17,8 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/yaml"
 )
+
+var kustomizeBuildMutex sync.Mutex
 
 type KustomizeOpts struct {
 	Path string
@@ -94,6 +97,9 @@ func (k *Kustomize) buildKustomization(path string) (resmap.ResMap, error) {
 		AddManagedbyLabel: false,
 		PluginConfig:      krusty.MakeDefaultOptions().PluginConfig,
 	}
+
+	kustomizeBuildMutex.Lock()
+	defer kustomizeBuildMutex.Unlock()
 
 	kustomizer := krusty.MakeKustomizer(buildOptions)
 	return kustomizer.Run(fs, path)


### PR DESCRIPTION
## Current situation 

See issue #52

## Proposal

This is an issue in an upstream library. See https://github.com/kubernetes-sigs/kustomize/issues/3659.
This workaround mutex locks the krusty build.
