### PR TITLE
helm: allow values from secret to be in stringData

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -347,10 +347,12 @@ func (h *Helm) composeValues(ctx context.Context, db map[ref]*resource.Resource,
 				valuesData = []byte(data)
 			}
 		case *corev1.Secret:
-			if data, ok := obj.Data[v.GetValuesKey()]; !ok {
-				return nil, fmt.Errorf("missing key '%s' in %s '%s'", v.GetValuesKey(), v.Kind, namespacedName)
-			} else {
+			if data, ok := obj.Data[v.GetValuesKey()]; ok {
+				valuesData = data
+			} else if data, ok := obj.StringData[v.GetValuesKey()]; ok {
 				valuesData = []byte(data)
+			} else {
+				return nil, fmt.Errorf("missing key '%s' in %s '%s'", v.GetValuesKey(), v.Kind, namespacedName)
 			}
 		default:
 			return nil, fmt.Errorf("unsupported ValuesReference kind '%s'", v.Kind)


### PR DESCRIPTION
While Kubernetes only stores `data` and not `stringData`, a GitOps repository might contain Secret manifests with `stringData`, this commit makes flux-build use that if the requested key is not found in `data`.