### PR TITLE
fix: exclude empty documents from helmreleases, add hook support #88, #89

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ docker pull ghcr.io/doodlescheduling/flux-build:v0
 | `--api-versions` | `API_VERSIONS` | `` | Kubernetes api versions used for Capabilities.APIVersions (See helm help) |
 | `--kube-version`  | `KUBE_VERSION` | `1.27.0` | Kubernetes version (Some helm charts validate manifests against a specific kubernetes version) |
 | `--output`  | `OUTPUT` | `/dev/stdout` | Path to output file |
+| `--include-helm-hooks` | `INCLUDE_HELM_HOOKS` | `false` | Include helm hooks in the output |
 
 
 ## Github Action

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,10 @@ require (
 	github.com/onsi/gomega v1.29.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/otiai10/copy v1.14.0
+	github.com/sethvargo/go-envconfig v1.0.0
 	github.com/sigstore/cosign v1.13.2
 	github.com/sigstore/sigstore v1.5.2
 	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.15.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/sync v0.4.0
 	helm.sh/helm/v3 v3.11.3
@@ -230,6 +230,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/viper v1.15.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 // indirect

--- a/go.sum
+++ b/go.sum
@@ -915,6 +915,8 @@ github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/sethvargo/go-envconfig v1.0.0 h1:1C66wzy4QrROf5ew4KdVw942CQDa55qmlYmw9FZxZdU=
+github.com/sethvargo/go-envconfig v1.0.0/go.mod h1:Lzc75ghUn5ucmcRGIdGQ33DKJrcjk4kihFYgSTBmjIc=
 github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh5dkI=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/build/index.go
+++ b/internal/build/index.go
@@ -28,3 +28,9 @@ func (r ResourceIndex) Push(resources []*resource.Resource) error {
 
 	return nil
 }
+
+type ref struct {
+	schema.GroupKind
+	Name      string
+	Namespace string
+}

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
     {
       "semanticCommitScope": "deps-dev",
       "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ],
   "postUpdateOptions": [

--- a/test/e2e/expected.yaml
+++ b/test/e2e/expected.yaml
@@ -9,10 +9,6 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    internal.config.kubernetes.io/previousKinds: Deployment
-    internal.config.kubernetes.io/previousNames: podinfo
-    internal.config.kubernetes.io/previousNamespaces: default
   labels:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: podinfo
@@ -139,10 +135,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    internal.config.kubernetes.io/previousKinds: Service
-    internal.config.kubernetes.io/previousNames: podinfo
-    internal.config.kubernetes.io/previousNamespaces: default
   labels:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: podinfo


### PR DESCRIPTION
## Current situation

The output may contain empty resources if a rendered HelmRelease produced an empty manifest.
Despite this helm hooks were not available in the output thus far.

## Proposal
Fix empty documents and make helm hooks available. This change is backwards compatible and sits behind a bool flag `--include-helm-hooks`.

Other changes:
* logger now logs by default as json
* replaced viper flag parsing with native and env config binding
