### PR TITLE
fix: throw error if malformed yaml

### DIFF
--- a/internal/build/kustomize.go
+++ b/internal/build/kustomize.go
@@ -136,7 +136,7 @@ func detectResources(fSys filesys.FileSystem, rf *resource.Factory, base string,
 			return err
 		}
 		if _, err := rf.SliceFromBytes(fContents); err != nil {
-			return nil
+			return err
 		}
 		paths = append(paths, normalizedPath)
 		return nil


### PR DESCRIPTION
## Current situation
If a malformed kube resource is passed to flux-build that error is ignored and flux-build exists with 0.

## Proposal
Throw error for any invalid resources passed to flux-build.
