### PR TITLE
feat: Add Helm charts caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker pull ghcr.io/doodlescheduling/flux-build:v0
 | `--workers`  | `WORKERS`  | `Number of CPU cores` | Workers used to template the HelmReleases. Greatly improves speed if there are many HelmReleases |
 | `--fail-fast`  | `FAIL_FAST` | `false` | Exit early if an error occured |
 | `--allow-failure`  | `ALLOW_FAILURE` | `false` | Do not exit > 0 if an error occured |
-| `--cache-dir`  | `CACHE_DIR`  | `` | Cache directory (for repositorieries, charts) |
+| `--cache-enabled`  | `CACHE_ENABLED`  | `true` | Enable Helm charts cache |
 | `--api-versions` | `API_VERSIONS` | `` | Kubernetes api versions used for Capabilities.APIVersions (See helm help) |
 | `--kube-version`  | `KUBE_VERSION` | `1.27.0` | Kubernetes version (Some helm charts validate manifests against a specific kubernetes version) |
 | `--output`  | `OUTPUT` | `/dev/stdout` | Path to output file |
@@ -148,7 +148,7 @@ jobs:
         openapi2jsonschema schemas/*.yaml
     - name: Run conform
       shell: bash
-      env: 
+      env:
         KUBERNETES_VERSION: "${{ inputs.kubernetes-version }}"
       run: |
         echo "kubeconform $m"
@@ -172,13 +172,13 @@ This means flux-build has not directly access to these secrets but some resource
 
 It depends whether the secrets value is actually a hard dependency or a soft one. Example for hard dependencies are if the secret is used in HelmRepository
 as repository credentials.
-If flux-build is used on a ci build, a way to achieve this is to store the plain v1.Secret as a ci secret and inject it into the folder which gets 
+If flux-build is used on a ci build, a way to achieve this is to store the plain v1.Secret as a ci secret and inject it into the folder which gets
 built by flux-build. Locally one might first need to pull the decrypted secret from the cluster.
 
 For soft dependencies meaning the actual secrets value is only required at runtime on the cluster but flux-build can use any value.
 To achieve this a good practice is to add a dummy secret which is available to flux-build but not synced to the cluster (Either by placing the dummies in a folder which is not targeted by a flux kustomization or by annotating
 the dummy secrets with `kustomize.toolkit.fluxcd.io/reconcile: disabled`).
-Examples for this case are usually if a HelmRelease refers to v1.Secrets as values. 
+Examples for this case are usually if a HelmRelease refers to v1.Secrets as values.
 
 
 ## License notice

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -19,7 +19,7 @@ type Action struct {
 	FailFast         bool
 	Workers          int
 	CacheDir         string
-	CacheSize        int
+	CacheEnabled     bool
 	Paths            []string
 	APIVersions      []string
 	IncludeHelmHooks bool
@@ -65,7 +65,7 @@ func (a *Action) Run(ctx context.Context) error {
 		APIVersions:      a.APIVersions,
 		KubeVersion:      a.KubeVersion,
 		IncludeHelmHooks: a.IncludeHelmHooks,
-		CacheSize:        a.CacheSize,
+		CacheEnabled:     a.CacheEnabled,
 	})
 
 	helmResultPool.Push(worker.Task(func(ctx context.Context) error {

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -19,6 +19,7 @@ type Action struct {
 	FailFast         bool
 	Workers          int
 	CacheDir         string
+	CacheSize        int
 	Paths            []string
 	APIVersions      []string
 	IncludeHelmHooks bool
@@ -60,10 +61,11 @@ func (a *Action) Run(ctx context.Context) error {
 
 	resources := make(chan resmap.ResMap, len(a.Paths))
 	manifests := make(chan resmap.ResMap, a.Workers)
-	helmBuilder := build.NewHelmBuilder(build.HelmOpts{
+	helmBuilder := build.NewHelmBuilder(a.Logger, build.HelmOpts{
 		APIVersions:      a.APIVersions,
 		KubeVersion:      a.KubeVersion,
 		IncludeHelmHooks: a.IncludeHelmHooks,
+		CacheSize:        a.CacheSize,
 	})
 
 	helmResultPool.Push(worker.Task(func(ctx context.Context) error {

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -490,6 +490,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	if err != nil {
 		return fmt.Errorf("failed to normalize url: %w", err)
 	}
+	h.Logger.V(1).Info("Using chart repo", "chartrepo", normalizedURL)
 
 	// Construct the Getter options from the HelmRepository data
 	clientOpts := []helmgetter.Option{
@@ -607,14 +608,14 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 		if h.Cache != nil {
 			if index, ok := h.Cache.Get(repo.GetArtifact().Path); ok {
 				httpChartRepo.Index = index.(*helmrepo.IndexFile)
-				h.Logger.V(1).Info("Got %s artifact from cache", repo.GetArtifact().Path)
+				h.Logger.V(1).Info("Got artifact from cache", "artifact", repo.GetArtifact().Path)
 			} else {
-				h.Logger.V(1).Info("Missed cach for artifact %s", repo.GetArtifact().Path)
+				h.Logger.V(1).Info("Missed cach for artifact", "artifact", repo.GetArtifact().Path)
 				defer func() {
 					// If we succeed in loading the index, cache it.
 					if httpChartRepo.Index != nil {
 						if err = h.Cache.Set(repo.GetArtifact().Path, httpChartRepo.Index, time.Hour); err != nil {
-							h.Logger.V(1).Info("Caching %s artifact", repo.GetArtifact().Path)
+							h.Logger.V(1).Info("Cached new artifact", "artifact", repo.GetArtifact().Path)
 						}
 					}
 				}()
@@ -638,7 +639,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	if h.Cache != nil {
 		if path, ok := h.Cache.Get(ref.Key()); ok {
 			opts.CachedChart = path.(string)
-			h.Logger.V(1).Info("Using cached artifact %s, with path %s", ref.Key(), path)
+			h.Logger.V(1).Info("Using cached chart artifact", "chart", ref.Key(), "path", path)
 		}
 	}
 
@@ -656,7 +657,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	}
 	if h.Cache != nil {
 		if err = h.Cache.Set(ref.Key(), path, time.Hour); err != nil {
-			h.Logger.V(1).Info("Cached %s artifact in path %s", ref.Key(), path)
+			h.Logger.V(1).Info("Cached new chart", "chart", ref.Key(), "path", path)
 		}
 	}
 

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -609,6 +609,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 				httpChartRepo.Index = index.(*helmrepo.IndexFile)
 				h.Logger.V(1).Info("Got %s artifact from cache", repo.GetArtifact().Path)
 			} else {
+				h.Logger.V(1).Info("Missed cach for artifact %s", repo.GetArtifact().Path)
 				defer func() {
 					// If we succeed in loading the index, cache it.
 					if httpChartRepo.Index != nil {

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -489,7 +489,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	if err != nil {
 		return fmt.Errorf("failed to normalize url: %w", err)
 	}
-	h.Logger.V(1).Info("Using chart repo", "chartrepo", normalizedURL)
+	h.Logger.V(1).Info("using chart repo", "chartrepo", normalizedURL)
 
 	// Construct the Getter options from the HelmRepository data
 	clientOpts := []helmgetter.Option{
@@ -641,7 +641,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 		if p, ok := h.Cache.GetOrLock(ref); ok {
 			path = p.(string)
 			opts.CachedChart = path
-			h.Logger.V(1).Info("Using cached chart artifact", "chart", ref.String(), "path", path)
+			h.Logger.V(1).Info("using cached chart artifact", "chart", ref.String(), "path", path)
 		}
 	}
 
@@ -658,7 +658,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	}
 	if h.Cache != nil {
 		h.Cache.SetUnlock(ref, path)
-		h.Logger.V(1).Info("Cached new chart", "chart", ref.String(), "path", path)
+		h.Logger.V(1).Info("cached new chart", "chart", ref.String(), "path", path)
 	}
 
 	*b = *build

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -638,7 +638,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	if h.Cache != nil {
 		if path, ok := h.Cache.Get(ref.Key()); ok {
 			opts.CachedChart = path.(string)
-			h.Logger.V(1).Info("Using cached artifact %s, with path %s", obj.GetArtifact().URL, path)
+			h.Logger.V(1).Info("Using cached artifact %s, with path %s", ref.Key(), path)
 		}
 	}
 
@@ -656,7 +656,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	}
 	if h.Cache != nil {
 		if err = h.Cache.Set(ref.Key(), path, time.Hour); err != nil {
-			h.Logger.V(1).Info("Cached %s artifact in path %s", repo.GetArtifact().Path, path)
+			h.Logger.V(1).Info("Cached %s artifact in path %s", ref.Key(), path)
 		}
 	}
 

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -654,7 +654,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	if err != nil {
 		return err
 	}
-	if h.Cache != nil {
+	if h.Cache != nil && obj.GetArtifact() != nil {
 		if err = h.Cache.Set(obj.GetArtifact().URL, path, time.Hour); err != nil {
 			h.Logger.V(1).Info("Cached %s artifact in path %s", repo.GetArtifact().Path, path)
 		}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -25,7 +25,7 @@ import (
 func TestCache(t *testing.T) {
 	g := NewWithT(t)
 	// create a cache that can hold 2 items
-	cache := New[string](2)
+	cache := New[string]()
 
 	// Get an Item from the cache
 	if _, found := cache.Get("key1"); found {
@@ -53,12 +53,11 @@ func TestCache(t *testing.T) {
 
 	//Add an item to the cache
 	err = cache.Add("key3", "value3")
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(cache.ItemCount()).To(Equal(2))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cache.ItemCount()).To(Equal(3))
 
 	// Replace an item in the cache
-	err = cache.Set("key2", "value3")
-	g.Expect(err).ToNot(HaveOccurred())
+	cache.Set("key2", "value3")
 
 	// Get the item from the cache
 	item, found = cache.Get("key2")
@@ -66,7 +65,7 @@ func TestCache(t *testing.T) {
 	g.Expect(item).To(Equal("value3"))
 
 	// new int cache
-	cache2 := New[int](2)
+	cache2 := New[int]()
 
 	// Add an item to the cache
 	err = cache2.Add(1, "value1")
@@ -87,6 +86,5 @@ func TestCache(t *testing.T) {
 		g.Expect(item).To(Equal("value3"))
 	}()
 
-	err = cache2.SetUnlock(3, "value3")
-	g.Expect(err).ToNot(HaveOccurred())
+	cache2.SetUnlock(3, "value3")
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -18,15 +18,14 @@ package cache
 
 import (
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 )
 
 func TestCache(t *testing.T) {
 	g := NewWithT(t)
-	// create a cache that can hold 2 items and have no cleanup
-	cache := New(2, 0)
+	// create a cache that can hold 2 items
+	cache := New[string](2)
 
 	// Get an Item from the cache
 	if _, found := cache.Get("key1"); found {
@@ -34,7 +33,7 @@ func TestCache(t *testing.T) {
 	}
 
 	// Add an item to the cache
-	err := cache.Add("key1", "value1", 0)
+	err := cache.Add("key1", "value1")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Get the item from the cache
@@ -43,7 +42,7 @@ func TestCache(t *testing.T) {
 	g.Expect(item).To(Equal("value1"))
 
 	// Add another item to the cache
-	err = cache.Add("key2", "value2", 0)
+	err = cache.Add("key2", "value2")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cache.ItemCount()).To(Equal(2))
 
@@ -53,11 +52,12 @@ func TestCache(t *testing.T) {
 	g.Expect(item).To(Equal("value2"))
 
 	//Add an item to the cache
-	err = cache.Add("key3", "value3", 0)
+	err = cache.Add("key3", "value3")
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(cache.ItemCount()).To(Equal(2))
 
 	// Replace an item in the cache
-	err = cache.Set("key2", "value3", 0)
+	err = cache.Set("key2", "value3")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Get the item from the cache
@@ -65,23 +65,28 @@ func TestCache(t *testing.T) {
 	g.Expect(found).To(BeTrue())
 	g.Expect(item).To(Equal("value3"))
 
-	// new cache with a cleanup interval of 1 second
-	cache = New(2, 1*time.Second)
+	// new int cache
+	cache2 := New[int](2)
 
 	// Add an item to the cache
-	err = cache.Add("key1", "value1", 2*time.Second)
+	err = cache2.Add(1, "value1")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Get the item from the cache
-	item, found = cache.Get("key1")
+	item, found = cache2.Get(1)
 	g.Expect(found).To(BeTrue())
 	g.Expect(item).To(Equal("value1"))
 
-	// wait for the item to expire
-	time.Sleep(3 * time.Second)
-
-	// Get the item from the cache
-	item, found = cache.Get("key1")
+	item, found = cache2.GetOrLock(3)
 	g.Expect(found).To(BeFalse())
-	g.Expect(item).To(BeNil())
+
+	go func() {
+		// Locks until item is set.
+		item, found = cache2.GetOrLock(3)
+		g.Expect(found).To(BeTrue())
+		g.Expect(item).To(Equal("value3"))
+	}()
+
+	err = cache2.SetUnlock(3, "value3")
+	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/internal/helm/chart/builder.go
+++ b/internal/helm/chart/builder.go
@@ -88,6 +88,11 @@ func (r RemoteReference) Validate() error {
 	return nil
 }
 
+// Key converts RemoteReference to a string key for caching.
+func (r RemoteReference) Key() string {
+	return fmt.Sprintf("%s%%%s", r.Name, r.Version)
+}
+
 // Builder is capable of building a (specific) chart Reference.
 type Builder interface {
 	// Build pulls and (optionally) packages a Helm chart with the given

--- a/internal/helm/chart/builder.go
+++ b/internal/helm/chart/builder.go
@@ -89,7 +89,7 @@ func (r RemoteReference) Validate() error {
 }
 
 // Key converts RemoteReference to a string key for caching.
-func (r RemoteReference) Key() string {
+func (r RemoteReference) String() string {
 	return fmt.Sprintf("%s%%%s", r.Name, r.Version)
 }
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ type Config struct {
 	Workers          int      `env:"WORKERS"`
 	APIVersions      []string `env:"API_VERSIONS"`
 	KubeVersion      string   `env:"KUBE_VERSION"`
-	CacheSize        int      `env:"CACHE_SIZE"`
+	CacheEnabled     bool     `env:"CACHE_ENABLED"`
 }
 
 var (
@@ -46,7 +46,7 @@ func init() {
 	flag.IntVar(&config.Workers, "workers", 0, "Workers used to parse manifests")
 	flag.StringVarP(&config.KubeVersion, "kube-version", "", "", "Kubernetes version (Some helm charts validate manifests against a specific kubernetes version)")
 	flag.StringSliceVarP(&config.APIVersions, "api-versions", "", nil, "Kubernetes api versions used for Capabilities.APIVersions (Comma separated)")
-	flag.IntVar(&config.CacheSize, "cache-size", 0, "Size of Helm cache")
+	flag.BoolVar(&config.CacheEnabled, "cache-enabled", true, "Is Helm charts cache enabled")
 }
 
 func must(err error) {
@@ -107,7 +107,7 @@ func main() {
 		Output:           out,
 		IncludeHelmHooks: config.IncludeHelmHooks,
 		Logger:           logger,
-		CacheSize:        config.CacheSize,
+		CacheEnabled:     config.CacheEnabled,
 	}
 
 	must(a.Run(ctx))

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type Config struct {
 	Workers          int      `env:"WORKERS"`
 	APIVersions      []string `env:"API_VERSIONS"`
 	KubeVersion      string   `env:"KUBE_VERSION"`
+	CacheSize        int      `env:"CACHE_SIZE"`
 }
 
 var (
@@ -45,6 +46,7 @@ func init() {
 	flag.IntVar(&config.Workers, "workers", 0, "Workers used to parse manifests")
 	flag.StringVarP(&config.KubeVersion, "kube-version", "", "", "Kubernetes version (Some helm charts validate manifests against a specific kubernetes version)")
 	flag.StringSliceVarP(&config.APIVersions, "api-versions", "", nil, "Kubernetes api versions used for Capabilities.APIVersions (Comma separated)")
+	flag.IntVar(&config.CacheSize, "cache-size", 0, "Size of Helm cache")
 }
 
 func must(err error) {
@@ -105,6 +107,7 @@ func main() {
 		Output:           out,
 		IncludeHelmHooks: config.IncludeHelmHooks,
 		Logger:           logger,
+		CacheSize:        config.CacheSize,
 	}
 
 	must(a.Run(context.TODO()))


### PR DESCRIPTION
Add `--cache-enabled` flag to enable cache. Default is enabled.

Rewrote `internal/cache` module to download any chart just once and wait in concurrent builds.

Fixes: #166
