### PR TITLE
fix: helm repository apiVersion race

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -182,13 +182,14 @@ func (h *Helm) Build(ctx context.Context, r *resource.Resource, db map[ref]*reso
 }
 
 func (h *Helm) getRepository(repository *resource.Resource) (runtime.Object, error) {
-	repository.SetGvk(resid.Gvk{
+	copy := repository.DeepCopy()
+	copy.SetGvk(resid.Gvk{
 		Group:   sourcev1.GroupVersion.Group,
 		Version: sourcev1.GroupVersion.Version,
 		Kind:    sourcev1.HelmRepositoryKind,
 	})
 
-	b, err := repository.AsYAML()
+	b, err := copy.AsYAML()
 	if err != nil {
 		return nil, fmt.Errorf("failed marshal repository as yaml: %w", err)
 	}


### PR DESCRIPTION
## Current situation
There is a race problem while rendering the outputs generated by the kustomize builds.
The helm builder gets the internal resource reference and modifies it for its own api requirements.
This leads to a race issue as the manifest output is rendered at the same time at it can happen that it would include the apiVersion change
eventhough it's supposed to dump the value from the fs.

This bug is probably in flux-build since the start and its only encounterable for users not using the same apiVersion in HelmRepositories as flux-build uses internally.

## Proposal
A simple clone should fix that.
