### PR TITLE
fix: apiversion race for HelmRelease

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -101,6 +101,7 @@ func NewHelmBuilder(logger logr.Logger, opts HelmOpts) *Helm {
 }
 
 func (h *Helm) Build(ctx context.Context, r *resource.Resource, db map[ref]*resource.Resource) (resmap.ResMap, error) {
+	r = r.DeepCopy()
 	r.SetGvk(resid.Gvk{
 		Group:   helmv2.GroupVersion.Group,
 		Version: helmv2.GroupVersion.Version,


### PR DESCRIPTION
## Current situation
There is a similar race condition as #213 for helmreleases.

## Proposal
copy resource. Probably some logice there should be changed but for now this fixes it.
