### PR TITLE
fix: reorder helm postrenderer

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -294,7 +294,6 @@ func (h *Helm) renderRelease(ctx context.Context, hr helmv2beta1.HelmRelease, va
 // a single combined post renderer.
 func (h *Helm) postRenderers(hr helmv2beta1.HelmRelease) (postrender.PostRenderer, error) {
 	var combinedRenderer = postrenderer.NewCombinedPostRenderer()
-	combinedRenderer.AddRenderer(postrenderer.NewPostRendererNamespace(&hr))
 
 	for _, r := range hr.Spec.PostRenderers {
 		if r.Kustomize != nil {
@@ -302,6 +301,7 @@ func (h *Helm) postRenderers(hr helmv2beta1.HelmRelease) (postrender.PostRendere
 		}
 	}
 	combinedRenderer.AddRenderer(postrenderer.NewPostRendererOriginLabels(&hr))
+	combinedRenderer.AddRenderer(postrenderer.NewPostRendererNamespace(&hr))
 
 	if combinedRenderer.Len() == 0 {
 		return nil, nil


### PR DESCRIPTION
## Current situation
The namespace postrenderer is applied before the kustomize renderer. This is actually wrong and is noticable in some edge cases.

## Proposal 
Add namespace renderer last.
