### PR TITLE
fix: repo cache race condition

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -495,6 +495,8 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 		chartRepo = r.(repository.Downloader)
 	}
 
+	defer h.repoCache.SetUnlock(repoCacheKey, chartRepo)
+
 	if chartRepo == nil {
 		h.Logger.V(1).Info("using chart repo", "chartrepo", normalizedURL)
 
@@ -623,7 +625,6 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	}
 
 	defer func() {
-		h.repoCache.SetUnlock(repoCacheKey, chartRepo)
 		_ = h.cache.SetUnlock(chartCacheKey)
 	}()
 

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -495,8 +495,6 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 		chartRepo = r.(repository.Downloader)
 	}
 
-	defer h.repoCache.SetUnlock(repoCacheKey, nil)
-
 	if chartRepo == nil {
 		h.Logger.V(1).Info("using chart repo", "chartrepo", normalizedURL)
 
@@ -605,8 +603,6 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 
 			chartRepo = httpChartRepo
 		}
-
-		h.repoCache.SetUnlock(repoCacheKey, chartRepo)
 	}
 
 	// Construct the chart builder with scoped configuration
@@ -627,6 +623,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	}
 
 	defer func() {
+		h.repoCache.SetUnlock(repoCacheKey, chartRepo)
 		_ = h.cache.SetUnlock(chartCacheKey)
 	}()
 


### PR DESCRIPTION
## Current situation
there is a race condition with the repo in memory cache.
This was introduced with #231 as a side effect of fixing #171.

## Proposal
the repo must only be unlocked once the release was fully built since the helm build command modifies the repository object.
Currently the repo lock is released before the build which can trigger a race condition if other go routines get cached repo object without the modification done by the initial lock helder.
