### PR TITLE
fix: do not replace namespace if namespace is already set by the templated resource

### DIFF
--- a/internal/helm/postrenderer/post_renderer_namespace.go
+++ b/internal/helm/postrenderer/post_renderer_namespace.go
@@ -2,11 +2,10 @@ package postrenderer
 
 import (
 	"bytes"
-	"encoding/json"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	"sigs.k8s.io/kustomize/api/filesys"
-	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
 )
 
 func NewPostRendererNamespace(release *v2.HelmRelease) *postRendererNamespace {
@@ -25,35 +24,24 @@ type postRendererNamespace struct {
 }
 
 func (k *postRendererNamespace) Run(renderedManifests *bytes.Buffer) (modifiedManifests *bytes.Buffer, err error) {
-	fs := filesys.MakeFsInMemory()
-	cfg := kustypes.Kustomization{}
-	cfg.APIVersion = kustypes.KustomizationVersion
-	cfg.Kind = kustypes.KustomizationKind
-	cfg.Namespace = k.namespace
+	resFactory := provider.NewDefaultDepProvider().GetResourceFactory()
+	resMapFactory := resmap.NewFactory(resFactory)
 
-	// Add rendered Helm output as input resource to the Kustomization.
-	const input = "helm-output.yaml"
-	cfg.Resources = append(cfg.Resources, input)
-	if err := writeFile(fs, input, renderedManifests); err != nil {
-		return nil, err
-	}
-
-	// Write kustomization config to file.
-	kustomization, err := json.Marshal(cfg)
+	resMap, err := resMapFactory.NewResMapFromBytes(renderedManifests.Bytes())
 	if err != nil {
 		return nil, err
 	}
-	if err := writeToFile(fs, "kustomization.yaml", kustomization); err != nil {
-		return nil, err
+
+	for _, resource := range resMap.Resources() {
+		if resource.GetNamespace() == "" {
+			resource.SetNamespace(k.namespace)
+		}
 	}
-	resMap, err := buildKustomization(fs, ".")
-	if err != nil {
-		return nil, err
-	}
+
 	yaml, err := resMap.AsYaml()
 	if err != nil {
 		return nil, err
 	}
-	return bytes.NewBuffer(yaml), nil
 
+	return bytes.NewBuffer(yaml), nil
 }

--- a/internal/helm/postrenderer/post_renderer_namespace.go
+++ b/internal/helm/postrenderer/post_renderer_namespace.go
@@ -34,7 +34,10 @@ func (k *postRendererNamespace) Run(renderedManifests *bytes.Buffer) (modifiedMa
 
 	for _, resource := range resMap.Resources() {
 		if resource.GetNamespace() == "" {
-			resource.SetNamespace(k.namespace)
+			err = resource.SetNamespace(k.namespace)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Current situation
flux-build fails if a helm chart contains one resource with a static namespace and one with the same name without a namespace.

What actually happens is that the postender fails because the namespace is injected via a kustomize transformer.

Executing a kustomize build given a single resource file:
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: new-namespace
resources:
- test.yaml
```

```
# Source: test.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: reports-server
  namespace: kube-system
  labels:
    helm.sh/chart: reports-server-0.1.1
    app.kubernetes.io/name: reports-server
    app.kubernetes.io/instance: reports-server
    app.kubernetes.io/version: "v0.1.1"
    app.kubernetes.io/managed-by: Helm
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: extension-apiserver-authentication-reader
subjects:
- kind: ServiceAccount
  name: reports-server
  namespace: reports-server
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: reports-server
  namespace: reports-server
  labels:
    helm.sh/chart: reports-server-0.1.1
    app.kubernetes.io/name: reports-server
    app.kubernetes.io/instance: reports-server
    app.kubernetes.io/version: "v0.1.1"
    app.kubernetes.io/managed-by: Helm
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: reports-server
subjects:
- kind: ServiceAccount
  name: reports-server
  namespace: reports-server
```

will lead to the same error as the namespace transformer will change the ns in both resources:
```
Error: namespace transformation produces ID conflict: [{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"annotations":{"internal.config.kubernetes.io/previousKinds":"RoleBinding","internal.config.kubernetes.io/previousNames":"reports-server","internal.config.kubernetes.io/previousNamespaces":"kube-system"},"labels":{"app.kubernetes.io/instance":"reports-server","app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"reports-server","app.kubernetes.io/version":"v0.1.1","helm.sh/chart":"reports-server-0.1.1"},"name":"reports-server","namespace":"x"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"extension-apiserver-authentication-reader"},"subjects":[{"kind":"ServiceAccount","name":"reports-server","namespace":"reports-server"}]} {"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"annotations":{"internal.config.kubernetes.io/previousKinds":"RoleBinding","internal.config.kubernetes.io/previousNames":"reports-server","internal.config.kubernetes.io/previousNamespaces":"reports-server"},"labels":{"app.kubernetes.io/instance":"reports-server","app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"reports-server","app.kubernetes.io/version":"v0.1.1","helm.sh/chart":"reports-server-0.1.1"},"name":"reports-server","namespace":"x"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"reports-server"},"subjects":[{"kind":"ServiceAccount","name":"reports-server","namespace":"reports-server"}]}]

```

### Proposal
Only set namespace in the postrender if the namespace is not set yet.