### PR TITLE
fix(helm): add URL escaping for chart names in RemoteReference

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -619,7 +619,7 @@ func (h *Helm) buildFromHelmRepository(ctx context.Context, obj *sourcev1beta2.H
 	}
 
 	ref := chart.RemoteReference{Name: obj.Spec.Chart, Version: obj.Spec.Version}
-	path, chartCacheKey, err := h.cache.GetOrLock(normalizedURL, ref)
+	path, chartCacheKey, err := h.cache.GetOrLock(normalizedURL, ref.WithEscapedName())
 	if err != nil {
 		return err
 	}

--- a/internal/helm/chart/builder.go
+++ b/internal/helm/chart/builder.go
@@ -19,6 +19,7 @@ package chart
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -73,6 +74,12 @@ type RemoteReference struct {
 	// Version of the chart.
 	// Can be a Semver range, or empty for latest.
 	Version string
+}
+
+// WithEscapedName returns a new RemoteReference with the Name URL-escaped.
+func (r RemoteReference) WithEscapedName() RemoteReference {
+	r.Name = url.PathEscape(r.Name)
+	return r
 }
 
 // Validate returns an error if the RemoteReference does not have


### PR DESCRIPTION
This pull request addresses an issue where Helm charts with paths cannot be used successfully, resulting in rendering failures.

## Configuration Example:

sources.yaml
```yaml
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: HelmRepository
metadata:
  name: docker
spec:
  type: oci
  interval: 30m
  url: oci://registry-1.docker.io
```

deployment.yaml
```yaml
spec:
  chart:
    spec:
      chart: bitnamicharts/wordpress
      sourceRef:
        kind: HelmRepository
        name: docker
      version: "20.1.3"
```

## Problem

This configuration causes an error during rendering:
```
{"L":"ERROR","T":"2024-11-29T22:47:48.427Z","C":"action/action.go:138","M":"failed build helmrelease","namespace":"clients","name":"wordpress","error":"chart pull error: failed to write chart to file: link error: cannot rename /tmp/wordpress%20.1.3-1c2bc7f4234ff535907d8903bb34d816.tgz298462887 to /tmp/helmcharts3763670751/76b499bb%bitnamicharts/wordpress%20.1.3-1c2bc7f4234ff535907d8903bb34d816.tgz: rename /tmp/wordpress%20.1.3-1c2bc7f4234ff535907d8903bb34d816.tgz298462887 /tmp/helmcharts3763670751/76b499bb%bitnamicharts/wordpress%20.1.3-1c2bc7f4234ff535907d8903bb34d816.tgz: no such file or directory","S":"github.com/doodlescheduling/flux-build/internal/action.(*Action).Run.func7\n\t/workspaces/flux-build/internal/action/action.go:138\ngithub.com/alitto/pond.(*WorkerPool).executeTask\n\t/go/pkg/mod/github.com/alitto/pond@v1.9.2/pond.go:461\ngithub.com/alitto/pond.worker\n\t/go/pkg/mod/github.com/alitto/pond@v1.9.2/worker.go:13"}
```

## Solution

The provided implementation escapes the chart name, ensuring that file operations like `mv` do not fail due to the presence of `/`. This prevents path-related errors during the rendering process.
