### PR TITLE
ci: deprecated goreleaser fields

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,8 +92,6 @@ homebrew_casks:
   description: Build kustomize overlays with flux2 HelmRelease support
   homepage: https://github.com/DoodleScheduling/flux-build
   directory: Formula
-  test: |
-    system "#{bin}/flux-build -h" 
 
 signs:
 - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
 archives:
 - id: flux-build
   name_template: "flux-build_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  builds:
+  ids:
   - flux-build
 
 checksum:
@@ -82,7 +82,7 @@ docker_manifests:
   - ghcr.io/doodlescheduling/{{ .ProjectName }}:v{{ .Version }}-amd64
   - ghcr.io/doodlescheduling/{{ .ProjectName }}:v{{ .Version }}-arm64v8
 
-brews:
+homebrew_casks:
 - ids:
   - flux-build
   repository:


### PR DESCRIPTION
Goreleaser action is failing due to deprecated fields:

Update archives.builds to [archives.ids](https://goreleaser.com/deprecations/#archivesbuilds)
Update brews to [homebrew_casks](https://goreleaser.com/deprecations/#brews)