### PR TITLE
ci: lock goreleaser config version to v2.9.0 in goreleaser action

### DIFF
--- a/.github/workflows/pr-goreleaser.yaml
+++ b/.github/workflows/pr-goreleaser.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Validate .goreleaser.yaml
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
-          version: latest
+          version: v2.9.0
           args: check
         env:
           RUNNER_TOKEN: ${{ github.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
 archives:
 - id: flux-build
   name_template: "flux-build_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  builds:
+  ids:
   - flux-build
 
 checksum:


### PR DESCRIPTION
Latest version of goreleaser config will use version 2.10.x where homebrew formulas are [deprecated](https://goreleaser.com/customization/homebrew_formulas/) and have been replaced with [Homebrew casks](https://goreleaser.com/customization/homebrew_casks/) which doesn't support `test` field in the config
Lock config version to v2.9.0 to unblock ci until config has been migrated to Homebrew casks