### PR TITLE
Add install.DisableSchemaValidation in renderRelease

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -276,6 +276,7 @@ func (h *Helm) renderRelease(ctx context.Context, hr helmv2.HelmRelease, values 
 	client.Timeout = install.GetTimeout(hr.GetTimeout()).Duration
 	client.DisableHooks = install.DisableHooks
 	client.DisableOpenAPIValidation = install.DisableOpenAPIValidation
+	client.SkipSchemaValidation = install.DisableSchemaValidation
 	client.Devel = true
 	client.EnableDNS = true
 


### PR DESCRIPTION
## Honor `spec.install.disableSchemaValidation` from HelmRelease

### What

Pass the HelmRelease `install.DisableSchemaValidation` field through to `client.SkipSchemaValidation` in `renderRelease`, matching the behavior of the real Flux helm-controller.

### Why

When a Helm chart ships an outdated `values.schema.json` (e.g. the Apache Airflow chart's `io.k8s.api.core.v1.Volume` definition doesn't include the `image` volume type introduced in Kubernetes v1.31), users set `disableSchemaValidation: true` on their HelmRelease to work around it.

The real helm-controller respects this flag, but `flux-build` currently ignores it because `renderRelease` never reads `install.DisableSchemaValidation`. This causes CI pipelines using `flux-build` to fail on valid HelmReleases.

### Change

One-line addition in `internal/build/helm.go`:

```go
client.SkipSchemaValidation = install.DisableSchemaValidation
```

### How to test

Use a HelmRelease with a chart whose schema rejects a valid value (e.g. Airflow chart + image volume):

```yaml
spec:
  install:
    disableSchemaValidation: true
  values:
    workers:
      extraVolumes:
        - name: my-vol
          image:
            reference: "ghcr.io/example/image:latest"
            pullPolicy: Always
```

**Before:** `flux-build` fails with `Additional property image is not allowed`
**After:** `flux-build` templates the HelmRelease successfully
As shown here #387 