### PR TITLE
fix: do not panic if metadata is not not set on helm repository entries

### DIFF
--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -91,6 +91,9 @@ func IndexFromBytes(b []byte) (*repo.IndexFile, error) {
 				cvs = append(cvs[:idx], cvs[idx+1:]...)
 				continue
 			}
+			if cvs[idx].Name == "" {
+				cvs[idx].Name = key
+			}
 			if cvs[idx].APIVersion == "" {
 				cvs[idx].APIVersion = chart.APIVersionV1
 			}

--- a/internal/helm/repository/chart_repository.go
+++ b/internal/helm/repository/chart_repository.go
@@ -64,6 +64,7 @@ func IndexFromFile(path string) (*repo.IndexFile, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return IndexFromBytes(b)
 }
 
@@ -84,9 +85,10 @@ func IndexFromBytes(b []byte) (*repo.IndexFile, error) {
 		return nil, repo.ErrNoAPIVersion
 	}
 
-	for _, cvs := range i.Entries {
+	for key, cvs := range i.Entries {
 		for idx := len(cvs) - 1; idx >= 0; idx-- {
-			if cvs[idx] == nil {
+			if cvs[idx] == nil || cvs[idx].Metadata == nil {
+				cvs = append(cvs[:idx], cvs[idx+1:]...)
 				continue
 			}
 			if cvs[idx].APIVersion == "" {
@@ -96,6 +98,7 @@ func IndexFromBytes(b []byte) (*repo.IndexFile, error) {
 				cvs = append(cvs[:idx], cvs[idx+1:]...)
 			}
 		}
+		i.Entries[key] = cvs
 	}
 
 	i.SortEntries()


### PR DESCRIPTION
```
worker exits from a panic: task panicked: runtime error: invalid memory address or nil pointer dereference, goroutine 41 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.26.2/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/alitto/pond/v2.invokeTask[...].func1()
	/home/runner/go/pkg/mod/github.com/alitto/pond/v2@v2.7.0/task.go:63 +0xa5
panic({0x240e2c0?, 0x42726b0?})
	/opt/hostedtoolcache/go/1.26.2/x64/src/runtime/panic.go:860 +0x13a
github.com/doodlescheduling/flux-build/internal/helm/repository.IndexFromBytes({0x13a7ebe02000, 0x76b52, 0x76b53})
	/home/runner/work/flux-build/flux-build/internal/helm/repository/chart_repository.go:92 +0x19f
github.com/doodlescheduling/flux-build/internal/helm/repository.IndexFromFile({0x13a7e73e00c0, 0x1f})
	/home/runner/work/flux-build/flux-build/internal/helm/repository/chart_repository.go:67 +0x13f
github.com/doodlescheduling/flux-build/internal/helm/repository.(*ChartRepository).LoadFromPath(0x13a7e225ebd0)
	/home/runner/work/flux-build/flux-build/internal/helm/repository/chart_repository.go:347 +0xe5
github.com/doodlescheduling/flux-build/internal/helm/repository.(*ChartRepository).StrategicallyLoadIndex(0x13a7e225ebd0)
	/home/runner/work/flux-build/flux-build/internal/helm/repository/chart_repository.go:330 +0xbe
github.com/doodlescheduling/flux-build/internal/helm/repository.(*ChartRepository).GetChartVersion(0x13a7e225ebd0, {0x13a7e67ab420, 0x19}, {0x13a7e0da3d30, 0x6})
	/home/runner/work/flux-build/flux-build/internal/helm/repository/chart_repository.go:167 +0x30
github.com/doodlescheduling/flux-build/internal/helm/chart.(*remoteChartBuilder).downloadFromRepository(0x7f009ef3fde0?, {0x2a55668, 0x13a7d4200730}, {0x2a55940, 0x13a7e225ebd0}, {{0x13a7e67ab420?, 0x70?}, {0x13a7e0da3d30?, 0x400a7e2106948?}}, {{0x0, ...}, ...})
	/home/runner/work/flux-build/flux-build/internal/helm/chart/builder_remote.go:129 +0x5f
github.com/doodlescheduling/flux-build/internal/helm/chart.(*remoteChartBuilder).Build(0x13a7e2106d50, {0x2a55668, 0x13a7d4200730}, {0x2a32b40?, 0x13a7e24798a0?}, {0x13a7e0de2230, 0x68}, {{0x0, 0x0}, {0x0, ...}, ...})
	/home/runner/work/flux-build/flux-build/internal/helm/chart/builder_remote.go:77 +0x1e9
github.com/doodlescheduling/flux-build/internal/build.(*Helm).buildFromHelmRepository(0x13a7d3f8da40, {0x2a55668, 0x13a7d4200730}, 0x13a7e2107088, 0x13a7d6a20c40, 0x13a7e2107b08, 0x13a7d4583d40)
	/home/runner/work/flux-build/flux-build/internal/build/helm.go:663 +0x1705
github.com/doodlescheduling/flux-build/internal/build.(*Helm).buildChart(_, {_, _}, {_, _}, {{{0x13a7e0da3cd0, 0xb}, {0x13a7e67ab380, 0x19}}, {{0x13a7e67ab400, ...}, ...}, ...}, ...)
	/home/runner/work/flux-build/flux-build/internal/build/helm.go:244 +0x16f
github.com/doodlescheduling/flux-build/internal/build.(*Helm).Build(0x13a7d3f8da40, {0x2a55668, 0x13a7d4200730}, 0x28b40fc?, 0x13a7d4583d40)
	/home/runner/work/flux-build/flux-build/internal/build/helm.go:168 +0x50a
github.com/doodlescheduling/flux-build/internal/action.(*Action).Run.func6()
	/home/runner/work/flux-build/flux-build/internal/action/action.go:147 +0x1e5
github.com/alitto/pond/v2.invokeTask[...]({0x227d240?, 0x13a7d85484c0?}, 0x1?)
	/home/runner/go/pkg/mod/github.com/alitto/pond/v2@v2.7.0/task.go:74 +0x9d
github.com/alitto/pond/v2.wrappedTask[...].Run(0x2a50e80)
	/home/runner/go/pkg/mod/github.com/alitto/pond/v2@v2.7.0/task.go:32 +0xe7
github.com/alitto/pond/v2.invokeTask[...]({0x22d9b80?, 0x13a7d8548500?}, 0x1?)
	/home/runner/go/pkg/mod/github.com/alitto/pond/v2@v2.7.0/task.go:76 +0xc4
github.com/alitto/pond/v2.(*pool).worker(0x13a7d3e20820, {0x22d9b80?, 0x13a7d9d3d4c0?})
	/home/runner/go/pkg/mod/github.com/alitto/pond/v2@v2.7.0/pool.go:265 +0x95
created by github.com/alitto/pond/v2.(*pool).launchWorker in goroutine 1
	/home/runner/go/pkg/mod/github.com/alitto/pond/v2@v2.7.0/pool.go:454 +0xf1

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of chart repository indexes: invalid entries lacking metadata are now removed, entries with missing names inherit their key-based name, and pruning persists so parsed indexes no longer retain malformed items. This improves reliability when reading chart repository data and prevents downstream errors from malformed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->