### PR TITLE
Add additional context to error messages to make fault discovery easier

### DIFF
--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -161,23 +161,23 @@ func (h *Helm) Build(ctx context.Context, r *resource.Resource, db map[ref]*reso
 
 	repository, err := h.getRepository(source)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot get repository for helmrelease %s/%s`: %w", hr.GetNamespace(), hr.GetName(), err)
 	}
 
 	chartBuild := &chart.Build{}
 	err = h.buildChart(ctx, repository, *hr, chartBuild, db)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot build chart for helmrelease `%s/%s`: %w", hr.GetNamespace(), hr.GetName(), err)
 	}
 
 	values, err := h.composeValues(ctx, db, *hr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot compute values for helmrelease `%s/%s`: %w", hr.GetNamespace(), hr.GetName(), err)
 	}
 
 	release, err := h.renderRelease(ctx, *hr, values, chartBuild)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot render helmrelease `%s/%s`: %w", hr.GetNamespace(), hr.GetName(), err)
 	}
 
 	ksDir, err := os.MkdirTemp("", "helmrelease")

--- a/internal/build/index.go
+++ b/internal/build/index.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kustomize/api/resource"
 )
@@ -33,4 +35,8 @@ type ref struct {
 	schema.GroupKind
 	Name      string
 	Namespace string
+}
+
+func (r ref) String() string {
+	return fmt.Sprintf("%s %s/%s", r.Group, r.Namespace, r.Name)
 }


### PR DESCRIPTION
While using flux-build, I did have some issues with incorrectly formatted secrets - however, due to missing context in the error messages, finding the secret in question was a bit hard.

This PR adds additional context to the error messages in these places as well as adding a `String()` method to the `ref` type, so that it also provides more information when used in error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for Helm operations with improved context information, making it easier to identify and resolve issues when operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->