### PR TITLE
Ignore non-yaml files

### DIFF
--- a/internal/build/kustomize.go
+++ b/internal/build/kustomize.go
@@ -153,6 +153,12 @@ func detectResources(fSys filesys.FileSystem, rf *resource.Factory, base string,
 			}
 			return nil
 		}
+
+		ext := filepath.Ext(normalizedPath)
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
 		fContents, err := fSys.ReadFile(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
Resolves #477

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore non-YAML files when scanning directories for kustomize resources; only `*.yaml` and `*.yml` are read. Resolves #477.

<sup>Written for commit 32996662d8ce131d4cf1c4c04e826b8c4748164e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DoodleScheduling/flux-build/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file scanning so only `.yaml` and `.yml` files are considered during resource detection.
  * Non-YAML files are now skipped earlier, reducing unexpected parsing attempts and related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->