### PR TITLE
Emit rendered resources in a deterministic order

### DIFF
--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"sync"
 
 	"github.com/alitto/pond/v2"
@@ -15,6 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 )
 
 type Action struct {
@@ -85,21 +87,16 @@ func (a *Action) Run(ctx context.Context) error {
 		Cache:            a.Cache,
 	})
 
-	submit(helmResultPool, func() {
-		for index := range manifests {
-			y, err := index.AsYaml()
-			if err != nil {
-				a.Logger.Error(err, "failed to encode as yaml")
-				errs <- err
-				continue
-			}
+	var collected []*resource.Resource
 
-			_, err = a.Output.Write(append([]byte("---\n"), y...))
-			if err != nil {
-				a.Logger.Error(err, "failed to write helm manifests to output")
-				errs <- err
-				continue
-			}
+	submit(helmResultPool, func() {
+		// Collect every rendered resource instead of writing it out as it
+		// arrives. The kustomize and helm worker pools complete in a
+		// non-deterministic order, so streaming here reshuffled the document
+		// order on every run even when the input was unchanged. This pool has a
+		// single worker, so appending to collected needs no extra locking.
+		for index := range manifests {
+			collected = append(collected, index.Resources()...)
 		}
 	}, errs, &panicForward)
 
@@ -158,8 +155,52 @@ func (a *Action) Run(ctx context.Context) error {
 	helmPool.StopAndWait()
 	close(manifests)
 	helmResultPool.StopAndWait()
+
+	// Emit the collected resources in a deterministic order (group, version,
+	// kind, namespace, name) so the output is a pure function of the input.
+	// Without this the concurrent pools above yield a different document order
+	// on every run, which produces spurious diffs for consumers that commit the
+	// rendered manifests to git.
+	sort.SliceStable(collected, func(i, j int) bool {
+		return less(collected[i], collected[j])
+	})
+
+	for _, res := range collected {
+		y, err := res.AsYAML()
+		if err != nil {
+			a.Logger.Error(err, "failed to encode as yaml")
+			errs <- err
+			continue
+		}
+
+		if _, err := a.Output.Write(append([]byte("---\n"), y...)); err != nil {
+			a.Logger.Error(err, "failed to write manifests to output")
+			errs <- err
+			continue
+		}
+	}
+
 	panicForward.Wait()
 	close(errs)
 
 	return nil
+}
+
+// less orders resources by group, version, kind, namespace and name, giving a
+// total ordering over the rendered resources so the output stream is stable.
+func less(a, b *resource.Resource) bool {
+	ai, bi := a.CurId(), b.CurId()
+
+	switch {
+	case ai.Group != bi.Group:
+		return ai.Group < bi.Group
+	case ai.Version != bi.Version:
+		return ai.Version < bi.Version
+	case ai.Kind != bi.Kind:
+		return ai.Kind < bi.Kind
+	case ai.Namespace != bi.Namespace:
+		return ai.Namespace < bi.Namespace
+	default:
+		return ai.Name < bi.Name
+	}
 }

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -200,7 +201,15 @@ func less(a, b *resource.Resource) bool {
 		return ai.Kind < bi.Kind
 	case ai.Namespace != bi.Namespace:
 		return ai.Namespace < bi.Namespace
-	default:
+	case ai.Name != bi.Name:
 		return ai.Name < bi.Name
+	default:
+		// Two documents share the same Kubernetes identity (an apply-time
+		// conflict in its own right). Fall back to comparing the rendered
+		// content so the output stays deterministic regardless of the order in
+		// which the concurrent workers produced them.
+		ay, _ := a.AsYAML()
+		by, _ := b.AsYAML()
+		return bytes.Compare(ay, by) < 0
 	}
 }

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -1,0 +1,106 @@
+package action
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	chartcache "github.com/doodlescheduling/flux-build/internal/helm/chart/cache"
+	"github.com/go-logr/logr"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+// manifests are intentionally supplied out of sorted order and spread across
+// separate kustomize paths so that the concurrent worker pools would, without
+// the deterministic sort in Run, emit them in a different order on every run.
+var testManifests = []struct {
+	file    string
+	content string
+}{
+	{"svc.yaml", "apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\n  namespace: test\nspec:\n  ports:\n  - port: 80\n"},
+	{"deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy\n  namespace: test\nspec:\n  selector:\n    matchLabels:\n      app: x\n  template:\n    metadata:\n      labels:\n        app: x\n    spec:\n      containers:\n      - name: c\n        image: nginx\n"},
+	{"cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: test\ndata:\n  a: b\n"},
+	{"ns.yaml", "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ns\n"},
+}
+
+func buildPaths(t *testing.T) []string {
+	t.Helper()
+
+	var paths []string
+	for _, m := range testManifests {
+		d := t.TempDir()
+		if err := os.WriteFile(filepath.Join(d, m.file), []byte(m.content), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		paths = append(paths, d)
+	}
+
+	return paths
+}
+
+func runAction(t *testing.T, paths []string) string {
+	t.Helper()
+
+	cache, err := chartcache.New("none", "")
+	if err != nil {
+		t.Fatalf("cache: %v", err)
+	}
+
+	var buf bytes.Buffer
+	a := Action{
+		Workers:     4,
+		Paths:       paths,
+		KubeVersion: &chartutil.KubeVersion{Major: "1", Minor: "31", Version: "1.31.0"},
+		Output:      &buf,
+		Logger:      logr.Discard(),
+		Cache:       cache,
+	}
+
+	if err := a.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	return buf.String()
+}
+
+func kindOrder(out string) []string {
+	var kinds []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "kind:") {
+			kinds = append(kinds, strings.TrimSpace(strings.TrimPrefix(line, "kind:")))
+		}
+	}
+	return kinds
+}
+
+// TestRunDeterministicOrder verifies the rendered output is byte-identical
+// across repeated runs and sorted by group/version/kind/namespace/name.
+func TestRunDeterministicOrder(t *testing.T) {
+	paths := buildPaths(t)
+
+	first := runAction(t, paths)
+
+	for i := 0; i < 10; i++ {
+		if got := runAction(t, paths); got != first {
+			t.Fatalf("output not deterministic on run %d:\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+
+	// Core group ("") sorts before "apps"; within core, kinds sort
+	// alphabetically. Deployment (apps/v1) therefore comes last.
+	want := []string{"ConfigMap", "Namespace", "Service", "Deployment"}
+	got := kindOrder(first)
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d resources, got %d (%v)", len(want), len(got), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resources not in deterministic sorted order:\nwant %v\ngot  %v", want, got)
+		}
+	}
+}

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -3,6 +3,7 @@ package action
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	chartcache "github.com/doodlescheduling/flux-build/internal/helm/chart/cache"
 	"github.com/go-logr/logr"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"sigs.k8s.io/yaml"
 )
 
 // manifests are intentionally supplied out of sorted order and spread across
@@ -24,6 +26,11 @@ var testManifests = []struct {
 	{"deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy\n  namespace: test\nspec:\n  selector:\n    matchLabels:\n      app: x\n  template:\n    metadata:\n      labels:\n        app: x\n    spec:\n      containers:\n      - name: c\n        image: nginx\n"},
 	{"cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: test\ndata:\n  a: b\n"},
 	{"ns.yaml", "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ns\n"},
+	// A ConfigMap in a namespace that sorts before "test" exercises the
+	// namespace comparison; a second ConfigMap in "test" whose name sorts
+	// before "cm" exercises the name comparison in less.
+	{"cm-other-ns.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: z-cm\n  namespace: alpha\ndata:\n  c: d\n"},
+	{"cm-same-ns.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a-cm\n  namespace: test\ndata:\n  e: f\n"},
 }
 
 func buildPaths(t *testing.T) []string {
@@ -66,14 +73,48 @@ func runAction(t *testing.T, paths []string) string {
 	return buf.String()
 }
 
-func kindOrder(out string) []string {
-	var kinds []string
-	for _, line := range strings.Split(out, "\n") {
-		if strings.HasPrefix(line, "kind:") {
-			kinds = append(kinds, strings.TrimSpace(strings.TrimPrefix(line, "kind:")))
+// identities parses the multi-document output stream into an ordered list of
+// "kind/namespace/name" identifiers, so tests can assert the exact emitted
+// order (not just the kinds).
+func identities(t *testing.T, out string) []string {
+	t.Helper()
+
+	var (
+		ids []string
+		cur []string
+	)
+
+	flush := func() {
+		doc := strings.TrimSpace(strings.Join(cur, "\n"))
+		cur = nil
+		if doc == "" {
+			return
 		}
+
+		var m struct {
+			Kind     string `json:"kind"`
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+		}
+		if err := yaml.Unmarshal([]byte(doc), &m); err != nil {
+			t.Fatalf("unmarshal document: %v\n%s", err, doc)
+		}
+
+		ids = append(ids, fmt.Sprintf("%s/%s/%s", m.Kind, m.Metadata.Namespace, m.Metadata.Name))
 	}
-	return kinds
+
+	for _, line := range strings.Split(out, "\n") {
+		if line == "---" {
+			flush()
+			continue
+		}
+		cur = append(cur, line)
+	}
+	flush()
+
+	return ids
 }
 
 // TestRunDeterministicOrder verifies the rendered output is byte-identical
@@ -90,9 +131,19 @@ func TestRunDeterministicOrder(t *testing.T) {
 	}
 
 	// Core group ("") sorts before "apps"; within core, kinds sort
-	// alphabetically. Deployment (apps/v1) therefore comes last.
-	want := []string{"ConfigMap", "Namespace", "Service", "Deployment"}
-	got := kindOrder(first)
+	// alphabetically. The three ConfigMaps come first, ordered by namespace
+	// (alpha before test) then name (a-cm before cm), which exercises the
+	// namespace and name comparison branches in less. Deployment (apps/v1)
+	// comes last.
+	want := []string{
+		"ConfigMap/alpha/z-cm",
+		"ConfigMap/test/a-cm",
+		"ConfigMap/test/cm",
+		"Namespace//ns",
+		"Service/test/svc",
+		"Deployment/test/deploy",
+	}
+	got := identities(t, first)
 
 	if len(got) != len(want) {
 		t.Fatalf("expected %d resources, got %d (%v)", len(want), len(got), got)


### PR DESCRIPTION
## Problem

`Action.Run` renders kustomize paths and HelmReleases on concurrent worker pools (`kustomizePool`, `helmPool`) and a single result worker writes each `ResMap` to the output **as it arrives**. Completion order is non-deterministic, so running `flux-build` twice against the *same, unchanged* input produces a reshuffled document stream every time.

This is a real problem for the tool's primary use case — rendering manifests in CI and committing the result to git (Argo-style source hydration). The rendered output changes on every run with no input change, producing an endless stream of no-op commits and diffs that are entirely reordering noise.

The repo already acknowledges this: `make e2e-test` pipes flux-build through `yq ea '[.] | sort_by(.kind) | .[] | splitDoc'` to get a stable comparison.

## Fix

Collect all rendered resources and sort them by `(group, version, kind, namespace, name)` — a total order — before writing. The output becomes a pure function of the input. Everything is already held in memory (`ResourceIndex`), so buffering the result set adds no meaningful overhead.

## Verification

- New regression test `TestRunDeterministicOrder` asserts the stream is byte-identical across repeated runs and in the expected sorted order (`go test -race` passes).
- Built the binary and ran it 3× against a real 4-HelmRelease overlay (flux2, flux2-sync, two gitlab-runner releases): output was byte-identical every time (identical `sha256`), 60 documents, correctly sorted. Before this change the same input yielded a different byte order on nearly every run.
- `go build ./...`, `go vet ./internal/action/...`, and `gofmt -l` are clean.

## Note

Once merged, the `yq ... sort_by(.kind) ...` workaround in the `e2e-test` Makefile target can be dropped, since flux-build now emits a deterministic order itself. I left the Makefile untouched here to keep the change focused; happy to include that cleanup if you'd prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `flux-build` output deterministic by buffering all rendered resources, sorting them, and adding a stable tie-breaker. This removes CI diff noise and prevents no-op commits when input hasn’t changed.

- **Bug Fixes**
  - Collect all resources and sort by group/version/kind/namespace/name, then write once for stable output.
  - When identities are identical, compare YAML bytes as a tie-breaker; extended `TestRunDeterministicOrder` to cover ns/name ordering and byte-stable output, making the `yq ... sort_by(.kind)` e2e workaround unnecessary.

<sup>Written for commit f02c2379cdb7a0a740b588ebdcae417e0c3e7244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DoodleScheduling/flux-build/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured rendered Kubernetes resources are consistently output in a stable, predictable order.
  * Improved repeatability of generated YAML across multiple runs.

* **Tests**
  * Added coverage verifying deterministic output and resource ordering for Helm and Kustomize rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->